### PR TITLE
WIP: refactor debian_package step

### DIFF
--- a/jenkins-job-generator/definitions/build-jobs.yml
+++ b/jenkins-job-generator/definitions/build-jobs.yml
@@ -531,13 +531,27 @@
                         build job: 'generate-cf-java-buildpack-data', propagate: false, wait: false
                     }}
                 }}
-                stage('Publish Debian Linux Packages') {{
+                stage('Build Debian Linux Packages') {{
                     when {{
-                        expression {{ env.VERIFICATION_RESULT != "2" && params.PUBLISH == true && params.RELEASE == true && JOB_NAME ==~ /((\S*)(release-linux_x86_64)(\S*))/ }}
+                        expression {{ env.VERIFICATION_RESULT != "2" && params.PUBLISH == true && params.RELEASE == true }}
                     }}
                     steps {{
-                        build job: 'debian-package', propagate: false, wait: true, parameters:
+                        build job: 'build-debian-package', propagate: false, wait: true, parameters:
                             [
+                                string(name: 'JOB_NAME', value: JOB_NAME),
+                                string(name: 'GIT_TAG_NAME', value: env.SAPMACHINE_VERSION),
+                                [$class: 'BooleanParameterValue', name: 'DEPLOY', value: true]
+                            ]
+                    }}
+                }}
+                stage('Publish Debian Linux Packages') {{
+                    when {{
+                        expression {{ env.VERIFICATION_RESULT != "2" && params.PUBLISH == true && params.RELEASE == true }}
+                    }}
+                    steps {{
+                        build job: 'publish-debian-package', propagate: false, wait: true, parameters:
+                            [
+                                string(name: 'JOB_NAME', value: JOB_NAME),
                                 string(name: 'GIT_TAG_NAME', value: env.SAPMACHINE_VERSION),
                                 [$class: 'BooleanParameterValue', name: 'DEPLOY', value: true]
                             ]

--- a/jenkins-job-generator/definitions/linux-package-jobs.yml
+++ b/jenkins-job-generator/definitions/linux-package-jobs.yml
@@ -1,5 +1,5 @@
 - job:
-    name: debian-package
+    name: build-debian-package
     description: 'Create a debian package.'
     project-type: pipeline
     concurrent: false
@@ -8,6 +8,10 @@
             num-to-keep: 100
             artifact-num-to-keep: 1
     parameters:
+        - string:
+            name: JOB_NAME
+            default: ''
+            description: 'The name of the job creating the package.'
         - string:
             name: GIT_TAG_NAME
             default: ''
@@ -38,6 +42,41 @@
                         }
                     }
                 }
+            }
+            post {
+                always {
+                    cleanWs deleteDirs: true, disableDeferredWipeout: true
+                }
+            }
+        }
+- job:
+    name: publish-debian-package
+    description: 'Publish a debian package.'
+    project-type: pipeline
+    concurrent: false
+    properties:
+        - build-discarder:
+            num-to-keep: 100
+            artifact-num-to-keep: 1
+    parameters:
+        - string:
+            name: JOB_NAME
+            default: ''
+            description: 'The name of the job creating the package.'
+        - string:
+            name: GIT_TAG_NAME
+            default: ''
+            description: 'The Git tag to create a debian package from.'
+        - bool:
+            name: DEPLOY
+            default: false
+            description: 'When set to true, the resulting debian package will be deployed to dist.sapmachine.io.'
+    dsl: |
+        pipeline {
+            agent {
+                label 'agent-ubuntu-local'
+            }
+            stages {
                 stage('Deploy') {
                     when {
                         expression { params.DEPLOY == true }


### PR DESCRIPTION
The debian-package build job was building and publishing artifacts. In order
to improve support for the aarch architecture this step should be devided
into two new jobs: build-debian-package and publish-debian-package.

The build-debian-package job produces new artifacts specific for the
target architecture. The parameter JOB_NAME tells the job for which
architecture packages should be build. In full builds this job will be
called twice, once for linux_x86_64 and once for linux_aarch_64

The publish-debian-package copies the artifacts created by the
build-debian-package job to the right location