### PR TITLE
Refactor debian_package step

### DIFF
--- a/jenkins-job-generator/definitions/build-jobs.yml
+++ b/jenkins-job-generator/definitions/build-jobs.yml
@@ -526,13 +526,25 @@
                         build job: 'generate-cf-java-buildpack-data', propagate: false, wait: false
                     }}
                 }}
+                stage('Build Debian Linux Packages') {{
+                    {docker_agent}
+                    when {{
+                        expression {{ env.VERIFICATION_RESULT != "2" && params.PUBLISH == true && params.RELEASE == true && JOB_NAME ==~ /((\S*)(release-linux_x86_64)(\S*))/ }}
+                    }}
+                    steps {
+                        sh 'rm -f *.deb'
+                        sh "python3 SapMachine-Infrastructure/lib/make_deb.py --tag=${params.GIT_TAG_NAME} --templates-directory=SapMachine-Infrastructure/debian-templates"
+                    }
+                }}
                 stage('Publish Debian Linux Packages') {{
                     when {{
                         expression {{ env.VERIFICATION_RESULT != "2" && params.PUBLISH == true && params.RELEASE == true && JOB_NAME ==~ /((\S*)(release-linux_x86_64)(\S*))/ }}
                     }}
+                    
                     steps {{
-                        build job: 'debian-package', propagate: false, wait: true, parameters:
+                        build job: 'publish-debian-package', propagate: false, wait: true, parameters:
                             [
+                                string(name: 'JOB_NAME', value: JOB_NAME),
                                 string(name: 'GIT_TAG_NAME', value: env.SAPMACHINE_VERSION),
                                 [$class: 'BooleanParameterValue', name: 'DEPLOY', value: true]
                             ]

--- a/jenkins-job-generator/definitions/linux-package-jobs.yml
+++ b/jenkins-job-generator/definitions/linux-package-jobs.yml
@@ -1,6 +1,6 @@
 - job:
-    name: debian-package
-    description: 'Create a debian package.'
+    name: publish-debian-package
+    description: 'Publish a debian package.'
     project-type: pipeline
     concurrent: false
     properties:
@@ -8,6 +8,10 @@
             num-to-keep: 100
             artifact-num-to-keep: 1
     parameters:
+        - string:
+            name: JOB_NAME
+            default: ''
+            description: 'The name of the job creating the package.'
         - string:
             name: GIT_TAG_NAME
             default: ''
@@ -22,26 +26,15 @@
                 label 'agent-ubuntu-local'
             }
             stages {
+                when {
+                    expression { params.DEPLOY == true }
+                }
                 stage("Checkout Infrastructure Repository") {
                     steps {
                         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
-                stage('Build') {
-                    steps {
-                        sh 'rm -f *.deb'
-                        sh "python3 SapMachine-Infrastructure/lib/make_deb.py --tag=${params.GIT_TAG_NAME} --templates-directory=SapMachine-Infrastructure/debian-templates"
-                    }
-                    post {
-                        success {
-                            archiveArtifacts allowEmptyArchive: true, artifacts: "*.deb"
-                        }
-                    }
-                }
                 stage('Deploy') {
-                    when {
-                        expression { params.DEPLOY == true }
-                    }
                     steps {
                             sh "cp -n *.deb /var/pkg/deb/amd64 || true"
                             sh "python3 SapMachine-Infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/amd64"


### PR DESCRIPTION
The debian-package build job was building and publishing artifacts. In order
to improve support for the aarch architecture this step should be devided
into two new parts: the "Build Debian Linux Packages" stage and a
publish-debian-package job.

The "Build Debian Linux Packages" stage produces new artifacts specific for the
target architecture. In full builds this stage will be
called twice, once for linux_x86_64 and once for linux_aarch_64

The publish-debian-package job copies the artifacts created by the
build-debian-package step to the right location