### PR TITLE
Rename the folder 'SapMachine-Infrastructure' to

### DIFF
--- a/jenkins-job-generator/definitions/build-async-prof-jobs.yml
+++ b/jenkins-job-generator/definitions/build-async-prof-jobs.yml
@@ -17,7 +17,7 @@
             docker_agent: |
                 agent {{
                     dockerfile {{
-                        dir "SapMachine-Infrastructure/dockerfiles/async/ppc64le"
+                        dir "SapMachine-infrastructure/dockerfiles/async/ppc64le"
                         reuseNode true
                         label "{platform}"
                     }}
@@ -26,7 +26,7 @@
             docker_agent: |
                 agent {{
                     dockerfile {{
-                        dir "SapMachine-Infrastructure/dockerfiles/async/x86_64"
+                        dir "SapMachine-infrastructure/dockerfiles/async/x86_64"
                         reuseNode true
                         label "{platform}"
                     }}
@@ -101,7 +101,7 @@
                             env.VERIFICATION_RESULT = "1"
                         }}
                         cleanWs deleteDirs: true, disableDeferredWipeout: true
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }}
                 }}
                 stage("Checkout Repository") {{
@@ -119,7 +119,7 @@
                     }}
                     steps {{
                         script {{
-                            sh "python3 SapMachine-Infrastructure/lib/download_boot_jdk.py -m ${{params.BUILD_JDK}} -d `pwd`"
+                            sh "python3 SapMachine-infrastructure/lib/download_boot_jdk.py -m ${{params.BUILD_JDK}} -d `pwd`"
                         }}
                     }}
                 }}
@@ -133,7 +133,7 @@
                         BUILD_JDK = "${{WORKSPACE}}/boot_jdk"
                     }}
                     steps {{
-                        sh 'SapMachine-Infrastructure/lib/build_asyncprof.sh'
+                        sh 'SapMachine-infrastructure/lib/build_asyncprof.sh'
                     }}
                 }}
                 stage("Test") {{
@@ -145,7 +145,7 @@
                         BUILD_JDK = "${{WORKSPACE}}/boot_jdk"
                     }}
                     steps {{
-                        sh 'SapMachine-Infrastructure/lib/test_asyncprof.sh'
+                        sh 'SapMachine-infrastructure/lib/test_asyncprof.sh'
                     }}
                 }}
                 stage('Archive') {{
@@ -168,7 +168,7 @@
                     steps {{
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
                             sh '''
-                            SapMachine-Infrastructure/lib/publish_async_prof.sh
+                            SapMachine-infrastructure/lib/publish_async_prof.sh
                             '''
                         }}
                     }}

--- a/jenkins-job-generator/definitions/build-jobs.yml
+++ b/jenkins-job-generator/definitions/build-jobs.yml
@@ -28,7 +28,7 @@
             docker_agent: &docker_agent_aarch64 |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/ubuntu_20_04/arm64"
+                                    dir "SapMachine-infrastructure/dockerfiles/ubuntu_20_04/arm64"
                                     reuseNode true
                                     label "linux_aarch64"
                                     additionalBuildArgs '--build-arg ARTIFACTORY_CREDS=\"$ARTIFACTORY_CREDS\"'
@@ -43,12 +43,12 @@
                                 expression {{ env.BUILD_INSTALLER_PACKAGES == "true" }}
                             }}
                             steps {{
-                                sh "python3 SapMachine-Infrastructure/lib/make_deb.py --tag=${{env.SAPMACHINE_VERSION}} --architecture={architecture|}"
+                                sh "python3 SapMachine-infrastructure/lib/make_deb.py --tag=${{env.SAPMACHINE_VERSION}} --architecture={architecture|}"
                             }}
                             post {{
                                 success {{
                                     stash includes: '*.deb', name: 'debPackage'
-                                    stash includes: 'SapMachine-Infrastructure/**', name: 'infra'
+                                    stash includes: 'SapMachine-infrastructure/**', name: 'infra'
                                 }}
                             }}
                         }}
@@ -65,7 +65,7 @@
                                 unstash 'infra'
                                 unstash 'debPackage'
                                 sh "cp -n *.deb /var/pkg/deb/{debarch|} || true"
-                                sh "python3 SapMachine-Infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/{debarch|}"
+                                sh "python3 SapMachine-infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/{debarch|}"
                             }}
                         }}
             generate_dockerfiles: &generate_dockerfiles |-
@@ -88,7 +88,7 @@
             docker_agent: &docker_agent_alpine_x86_64 |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/alpine_3/x86_64"
+                                    dir "SapMachine-infrastructure/dockerfiles/alpine_3/x86_64"
                                     reuseNode true
                                     label "linux_alpine_x86_64"
                                 }}
@@ -102,7 +102,7 @@
             docker_agent: &docker_agent_ppc64le |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/ubuntu_20_04/ppc64le"
+                                    dir "SapMachine-infrastructure/dockerfiles/ubuntu_20_04/ppc64le"
                                     reuseNode true
                                     label "linux_ppc64le"
                                     additionalBuildArgs '--build-arg ARTIFACTORY_CREDS=\"$ARTIFACTORY_CREDS\"'
@@ -121,7 +121,7 @@
             docker_agent: &docker_agent_x86_64 |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/ubuntu_20_04/x86_64"
+                                    dir "SapMachine-infrastructure/dockerfiles/ubuntu_20_04/x86_64"
                                     reuseNode true
                                     label "linux_x86_64"
                                     additionalBuildArgs '--build-arg ARTIFACTORY_CREDS=\"$ARTIFACTORY_CREDS\"'
@@ -135,7 +135,7 @@
                 stage("Build RPM Packages") {{
                             agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/fedora-rpm"
+                                    dir "SapMachine-infrastructure/dockerfiles/fedora-rpm"
                                     reuseNode true
                                     label "linux_x86_64"
                                 }}
@@ -145,7 +145,7 @@
                                 expression {{ env.BUILD_INSTALLER_PACKAGES == "true" }}
                             }}
                             steps {{
-                                sh "python3 SapMachine-Infrastructure/lib/make_rpm.py --tag=${{env.SAPMACHINE_VERSION}}"
+                                sh "python3 SapMachine-infrastructure/lib/make_rpm.py --tag=${{env.SAPMACHINE_VERSION}}"
                             }}
                         }}
             publish_debian_packages: *publish_debian_packages
@@ -170,7 +170,7 @@
                             steps {{
                                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
                                     lock('MacBrewCaskGenerationSynchronizer') {{
-                                        sh "python3 SapMachine-Infrastructure/lib/make_cask.py -t $SAPMACHINE_VERSION"
+                                        sh "python3 SapMachine-infrastructure/lib/make_cask.py -t $SAPMACHINE_VERSION"
                                     }}
                                 }}
                             }}
@@ -193,8 +193,8 @@
                                         jdk_bundle_name = jdk_bundle_name.trim()
                                         jre_bundle_name = jre_bundle_name.trim()
 
-                                        sh "python3 SapMachine-Infrastructure/lib/make_msi.py --sapmachine-directory=`pwd`/SapMachine --asset=${{jdk_bundle_name}}"
-                                        sh "python3 SapMachine-Infrastructure/lib/make_msi.py --sapmachine-directory=`pwd`/SapMachine --jre --asset=${{jre_bundle_name}}"
+                                        sh "python3 SapMachine-infrastructure/lib/make_msi.py --sapmachine-directory=`pwd`/SapMachine --asset=${{jdk_bundle_name}}"
+                                        sh "python3 SapMachine-infrastructure/lib/make_msi.py --sapmachine-directory=`pwd`/SapMachine --jre --asset=${{jre_bundle_name}}"
                                     }}
                                 }}
                             }}
@@ -262,7 +262,7 @@
                                     script {{
                                         env.COMMENT = ('{platform}' == 'linux_x86_64') ? "-c" : ""
                                         env.VERIFICATION_RESULT = sh(
-                                            script: "python3 SapMachine-Infrastructure/lib/verify_pr.py -p ${{env.GITHUB_PR_NUMBER}} ${{env.COMMENT}}",
+                                            script: "python3 SapMachine-infrastructure/lib/verify_pr.py -p ${{env.GITHUB_PR_NUMBER}} ${{env.COMMENT}}",
                                             returnStatus: true
                                         )
 
@@ -387,7 +387,7 @@
                             }}
                             steps {{
                                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
-                                    sh "SapMachine-Infrastructure/lib/publish.sh"
+                                    sh "SapMachine-infrastructure/lib/publish.sh"
                                 }}
                             }}
                         }}
@@ -444,7 +444,7 @@
 
                             "$GIT_TOOL" --version
                             set -ex
-                            "$GIT_TOOL" init SapMachine-Infrastructure && cd SapMachine-Infrastructure
+                            "$GIT_TOOL" init SapMachine-infrastructure && cd SapMachine-infrastructure
                             GIT_TERMINAL_PROMPT=0 "$GIT_TOOL" fetch --depth 1 https://github.com/SAP/SapMachine-infrastructure.git master
                             "$GIT_TOOL" checkout --detach FETCH_HEAD
                         '''
@@ -456,7 +456,7 @@
                 stage("Checkout SapMachine Repository") {{
                     {verification_when|}
                     steps {{
-                        sh("SapMachine-Infrastructure/lib/git_clone.sh $SAPMACHINE_GIT_REPOSITORY SapMachine $GIT_REF")
+                        sh("SapMachine-infrastructure/lib/git_clone.sh $SAPMACHINE_GIT_REPOSITORY SapMachine $GIT_REF")
                     }}
                 }}
                 stage("Prepare Devkit") {{
@@ -470,7 +470,7 @@
                             String[] gav = params.DEVKIT.split(":");
                             if (gav.length == 3) {{
                                 echo "Extracting devkit from GAV coordinates: \"${{params.DEVKIT}}\"."
-                                sh("SapMachine-Infrastructure/lib/deploy-devkit.sh ${{gav[0]}} ${{gav[1]}} ${{gav[2]}}")
+                                sh("SapMachine-infrastructure/lib/deploy-devkit.sh ${{gav[0]}} ${{gav[1]}} ${{gav[2]}}")
                                 env.DEVKIT_PATH = sh(script: "cat devkitlocation.txt", returnStdout: true).trim()
                             }} else {{
                                 echo "Devkit not in GAV notation, assuming path."
@@ -486,16 +486,16 @@
                     steps {{
                         // Download Boot JDK, Credentials are needed to avoid rate limit exceedance
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
-                            sh "python3 SapMachine-Infrastructure/lib/download_boot_jdk.py -d `pwd`"
+                            sh "python3 SapMachine-infrastructure/lib/download_boot_jdk.py -d `pwd`"
                         }}
 
                         // Download googletest
-                        sh("SapMachine-Infrastructure/lib/git_clone.sh https://github.com/google/googletest.git gtest refs/tags/{gtest_version|release-1.8.1}")
+                        sh("SapMachine-infrastructure/lib/git_clone.sh https://github.com/google/googletest.git gtest refs/tags/{gtest_version|release-1.8.1}")
 
                         // Download jtreg if required
                         script {{
                             if (params.RUN_TESTS) {{
-                                sh "python3 SapMachine-Infrastructure/lib/download_jtreg.py"
+                                sh "python3 SapMachine-infrastructure/lib/download_jtreg.py"
                             }}
                         }}
                     }}
@@ -509,7 +509,7 @@
                     steps {{
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
                             script {{
-                                sh("SapMachine-Infrastructure/lib/build.sh")
+                                sh("SapMachine-infrastructure/lib/build.sh")
                                 {get_art_ver|}
                             }}
                         }}
@@ -525,7 +525,7 @@
                         TESTSUITE = 'hotspot'
                     }}
                     steps {{
-                        sh "bash SapMachine-Infrastructure/lib/run_jtreg.sh -l `pwd`/SapMachine -h `pwd`/jtreg/jtreg -s ${{env.TESTSUITE}} ${{params.hotspot_test_groups}} || true"
+                        sh "bash SapMachine-infrastructure/lib/run_jtreg.sh -l `pwd`/SapMachine -h `pwd`/jtreg/jtreg -s ${{env.TESTSUITE}} ${{params.hotspot_test_groups}} || true"
                         publishHTML target: [
                             allowMissing: false,
                             alwaysLinkToLastBuild: false,
@@ -553,7 +553,7 @@
                         TESTSUITE = 'jdk'
                     }}
                     steps {{
-                        sh "bash SapMachine-Infrastructure/lib/run_jtreg.sh -l `pwd`/SapMachine -h `pwd`/jtreg/jtreg -s ${{env.TESTSUITE}} ${{params.jdk_test_groups}} || true"
+                        sh "bash SapMachine-infrastructure/lib/run_jtreg.sh -l `pwd`/SapMachine -h `pwd`/jtreg/jtreg -s ${{env.TESTSUITE}} ${{params.jdk_test_groups}} || true"
 
                         publishHTML target: [
                             allowMissing: false,
@@ -582,7 +582,7 @@
                         TESTSUITE = 'langtools'
                     }}
                     steps {{
-                        sh "bash SapMachine-Infrastructure/lib/run_jtreg.sh -l `pwd`/SapMachine -h `pwd`/jtreg/jtreg -s ${{env.TESTSUITE}} ${{params.langtools_test_groups}} || true"
+                        sh "bash SapMachine-infrastructure/lib/run_jtreg.sh -l `pwd`/SapMachine -h `pwd`/jtreg/jtreg -s ${{env.TESTSUITE}} ${{params.langtools_test_groups}} || true"
 
                         publishHTML target: [
                             allowMissing: false,

--- a/jenkins-job-generator/definitions/cloud-foundry-jobs.yml
+++ b/jenkins-job-generator/definitions/cloud-foundry-jobs.yml
@@ -17,20 +17,20 @@
               stages {
                   stage("Checkout Infrastructure Repository") {
                       steps {
-                          checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                          checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                       }
                   }
                   stage('Generate') {
                       agent {
                           dockerfile {
-                              dir 'SapMachine-Infrastructure/dockerfiles/infrastructure'
+                              dir 'SapMachine-infrastructure/dockerfiles/infrastructure'
                               reuseNode true
                               label "cloud_foundry"
                           }
                       }
                       steps {
                           withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                              sh "python3 SapMachine-Infrastructure/lib/generate_cf_buildpack_data.py"
+                              sh "python3 SapMachine-infrastructure/lib/generate_cf_buildpack_data.py"
                           }
                       }
                   }
@@ -61,19 +61,19 @@
               stages {
                   stage("Checkout Infrastructure Repository") {
                       steps {
-                          checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                          checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                       }
                   }
                   stage('Test') {
                       agent {
                           dockerfile {
                               label 'cloud_foundry'
-                              dir 'SapMachine-Infrastructure/dockerfiles/infrastructure'
+                              dir 'SapMachine-infrastructure/dockerfiles/infrastructure'
                               reuseNode true
                           }
                       }
                       steps {
-                          sh "python3 SapMachine-Infrastructure/lib/test_cf_buildpack_data.py"
+                          sh "python3 SapMachine-infrastructure/lib/test_cf_buildpack_data.py"
                       }
                   }
               }

--- a/jenkins-job-generator/definitions/devkit-jobs.yml
+++ b/jenkins-job-generator/definitions/devkit-jobs.yml
@@ -7,7 +7,7 @@
             docker_agent: |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/devkits/dockerfiles/arm64"
+                                    dir "SapMachine-infrastructure/devkits/dockerfiles/arm64"
                                     reuseNode true
                                     label "{platform}"
                                 }}
@@ -18,7 +18,7 @@
             docker_agent: |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/devkits/dockerfiles/ppc64le"
+                                    dir "SapMachine-infrastructure/devkits/dockerfiles/ppc64le"
                                     reuseNode true
                                     label "{platform}"
                                 }}
@@ -45,7 +45,7 @@
             docker_agent: |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/devkits/dockerfiles/x86_64"
+                                    dir "SapMachine-infrastructure/devkits/dockerfiles/x86_64"
                                     reuseNode true
                                     label "{platform}"
                                 }}
@@ -100,7 +100,7 @@
             stages {{
                 stage("Checkout Infrastructure Repository") {{
                     steps {{
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }}
                 }}
                 stage("Checkout SapMachine Repository") {{

--- a/jenkins-job-generator/definitions/docker-jobs.yml
+++ b/jenkins-job-generator/definitions/docker-jobs.yml
@@ -15,19 +15,19 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Generate Manifest') {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                            dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                             reuseNode true
                             label "docker"
                         }
                     }
                     steps {
-                        sh "cd SapMachine-Infrastructure && python3 lib/make_docker_manifest.py -d dockerfiles/official -m ../sapmachine.manifest"
+                        sh "cd SapMachine-infrastructure && python3 lib/make_docker_manifest.py -d dockerfiles/official -m ../sapmachine.manifest"
                         archiveArtifacts 'sapmachine.manifest'
                     }
                 }
@@ -61,13 +61,13 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Generate Dockerfiles') {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                            dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                             reuseNode true
                             label "docker"
                         }
@@ -81,7 +81,7 @@
                             }
                         }
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                            sh "cd SapMachine-Infrastructure && python3 lib/generate_dockerfiles.py $FORCE_REGENERATE"
+                            sh "cd SapMachine-infrastructure && python3 lib/generate_dockerfiles.py $FORCE_REGENERATE"
                         }
                     }
                 }

--- a/jenkins-job-generator/definitions/jenkins-jobs.yml
+++ b/jenkins-job-generator/definitions/jenkins-jobs.yml
@@ -53,7 +53,7 @@
                     steps {
                         sh '''#!/bin/bash
                             set -ex
-                            git init --initial-branch=master SapMachine-Infrastructure && cd SapMachine-Infrastructure
+                            git init --initial-branch=master SapMachine-infrastructure && cd SapMachine-infrastructure
                             git fetch --depth 1 https://github.com/SAP/SapMachine-infrastructure.git master
                             git checkout --detach FETCH_HEAD
                         '''
@@ -62,7 +62,7 @@
                 stage('Backup') {
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
-                            sh('python3 SapMachine-Infrastructure/lib/jenkins_backup.py -s /var/jenkins_home')
+                            sh('python3 SapMachine-infrastructure/lib/jenkins_backup.py -s /var/jenkins_home')
                         }
                     }
                 }
@@ -95,7 +95,7 @@
                     steps {
                         sh '''#!/bin/bash
                             set -ex
-                            git init --initial-branch=master SapMachine-Infrastructure && cd SapMachine-Infrastructure
+                            git init --initial-branch=master SapMachine-infrastructure && cd SapMachine-infrastructure
                             git fetch --depth 1 https://github.com/SAP/SapMachine-infrastructure.git master
                             git checkout --detach FETCH_HEAD
                         '''
@@ -103,7 +103,7 @@
                 }
                 stage('Backup') {
                     steps {
-                        sh('python3 SapMachine-Infrastructure/lib/jenkins_restore.py -t /var/jenkins_home --install-plugins')
+                        sh('python3 SapMachine-infrastructure/lib/jenkins_restore.py -t /var/jenkins_home --install-plugins')
                     }
                 }
             }

--- a/jenkins-job-generator/definitions/jmc-jobs.yml
+++ b/jenkins-job-generator/definitions/jmc-jobs.yml
@@ -11,7 +11,7 @@
             docker_agent: |
                 agent {{
                     dockerfile {{
-                        dir "SapMachine-Infrastructure/dockerfiles/jmc/x86_64"
+                        dir "SapMachine-infrastructure/dockerfiles/jmc/x86_64"
                         reuseNode true
                         label "{platform}"
                     }}
@@ -76,7 +76,7 @@
                     steps {{
                         sh '''#!/bin/bash
                             set -ex
-                            git init SapMachine-Infrastructure && cd SapMachine-Infrastructure
+                            git init SapMachine-infrastructure && cd SapMachine-infrastructure
                             git fetch --depth 1 https://github.com/SAP/SapMachine-infrastructure.git master
                             git checkout --detach FETCH_HEAD
                         '''
@@ -98,7 +98,7 @@
                     steps {{
                         // credentials are needed to avoid rate limit exceedance
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
-                            sh "python3 SapMachine-Infrastructure/lib/download_boot_jdk.py -m ${{params.BUILD_JDK}} -d `pwd`"
+                            sh "python3 SapMachine-infrastructure/lib/download_boot_jdk.py -m ${{params.BUILD_JDK}} -d `pwd`"
                         }}
                     }}
                 }}
@@ -109,7 +109,7 @@
                         JAVA_HOME = "${{WORKSPACE}}/boot_jdk"
                     }}
                     steps {{
-                        sh 'SapMachine-Infrastructure/lib/jmc/build.sh'
+                        sh 'SapMachine-infrastructure/lib/jmc/build.sh'
                     }}
                 }}
                 stage("Test") {{
@@ -123,7 +123,7 @@
                     }}
                     steps {{
                         catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {{
-                            sh 'SapMachine-Infrastructure/lib/jmc/test.sh'
+                            sh 'SapMachine-infrastructure/lib/jmc/test.sh'
                         }}
                     }}
                 }}
@@ -294,7 +294,7 @@
                     steps {
                         sh '''#!/bin/bash
                             set -ex
-                            git init SapMachine-Infrastructure && cd SapMachine-Infrastructure
+                            git init SapMachine-infrastructure && cd SapMachine-infrastructure
                             git fetch --depth 1 https://github.com/SAP/SapMachine-infrastructure.git master
                             git checkout --detach FETCH_HEAD
                         '''
@@ -311,7 +311,7 @@
                     }
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
-                            sh "SapMachine-Infrastructure/lib/jmc/update_repo.sh"
+                            sh "SapMachine-infrastructure/lib/jmc/update_repo.sh"
                         }
                     }
                 }
@@ -321,7 +321,7 @@
                     }
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
-                            sh "cd jmc && python3 ../SapMachine-Infrastructure/lib/jmc/merge_from_upstream.py"
+                            sh "cd jmc && python3 ../SapMachine-infrastructure/lib/jmc/merge_from_upstream.py"
                         }
                     }
                 }

--- a/jenkins-job-generator/definitions/jtreg-job.yml
+++ b/jenkins-job-generator/definitions/jtreg-job.yml
@@ -26,7 +26,7 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage("Checkout JTReg") {
@@ -38,7 +38,7 @@
                     agent {
                         dockerfile {
                             label 'linux_x86_64'
-                            dir "SapMachine-Infrastructure/dockerfiles/jtreg-build"
+                            dir "SapMachine-infrastructure/dockerfiles/jtreg-build"
                             reuseNode true
                         }
                     }

--- a/jenkins-job-generator/definitions/linux-package-jobs.yml
+++ b/jenkins-job-generator/definitions/linux-package-jobs.yml
@@ -7,7 +7,7 @@
             docker_agent: |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/ubuntu_20_04/arm64"
+                                    dir "SapMachine-infrastructure/dockerfiles/ubuntu_20_04/arm64"
                                     reuseNode true
                                     label "{platform}"
                                     additionalBuildArgs '--build-arg ARTIFACTORY_CREDS=\"$ARTIFACTORY_CREDS\"'
@@ -19,7 +19,7 @@
             docker_agent: |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/ubuntu_20_04/ppc64le"
+                                    dir "SapMachine-infrastructure/dockerfiles/ubuntu_20_04/ppc64le"
                                     reuseNode true
                                     label "{platform}"
                                     additionalBuildArgs '--build-arg ARTIFACTORY_CREDS=\"$ARTIFACTORY_CREDS\"'
@@ -31,7 +31,7 @@
             docker_agent: |-
                 agent {{
                                 dockerfile {{
-                                    dir "SapMachine-Infrastructure/dockerfiles/ubuntu_20_04/x86_64"
+                                    dir "SapMachine-infrastructure/dockerfiles/ubuntu_20_04/x86_64"
                                     reuseNode true
                                     label "{platform}"
                                     additionalBuildArgs '--build-arg ARTIFACTORY_CREDS=\"$ARTIFACTORY_CREDS\"'
@@ -75,7 +75,7 @@
             stages {{
                 stage("Checkout Infrastructure Repository") {{
                     steps {{
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }}
                 }}
                 stage("Build") {{
@@ -83,14 +83,14 @@
                     steps {{
                         // credentials are needed to avoid rate limit exceedance
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {{
-                            sh "python3 SapMachine-Infrastructure/lib/make_deb.py --tag=${{params.GIT_TAG_NAME}} --download --architecture={architecture}"
+                            sh "python3 SapMachine-infrastructure/lib/make_deb.py --tag=${{params.GIT_TAG_NAME}} --download --architecture={architecture}"
                         }}
                     }}
                     post {{
                         success {{
                             archiveArtifacts allowEmptyArchive: true, artifacts: "*.deb"
                             stash includes: '*.deb', name: 'debPackage'
-                            stash includes: 'SapMachine-Infrastructure/**', name: 'infra'
+                            stash includes: 'SapMachine-infrastructure/**', name: 'infra'
                         }}
                     }}
                 }}
@@ -102,7 +102,7 @@
                         unstash 'infra'
                         unstash 'debPackage'
                         sh "cp -n *.deb /var/pkg/deb/{debarch} || true"
-                        sh "python3 SapMachine-Infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/{debarch}"
+                        sh "python3 SapMachine-infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/{debarch}"
                     }}
                 }}
             }}
@@ -138,12 +138,12 @@
             stages {{
                 stage("Checkout Infrastructure Repository") {{
                     steps {{
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }}
                 }}
                 stage("Recreate") {{
                     steps {{
-                        sh "python3 SapMachine-Infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/{debarch}"
+                        sh "python3 SapMachine-infrastructure/lib/recreate_deb_repository.py -s -r /var/pkg/deb/{debarch}"
                     }}
                 }}
             }}
@@ -180,20 +180,20 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage("Build") {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/fedora-rpm"
+                            dir "SapMachine-infrastructure/dockerfiles/fedora-rpm"
                             reuseNode true
                             label "linux_x86_64"
                         }
                     }
                     steps {
                         sh 'rm -f *.rpm'
-                        sh "/usr/bin/python3 SapMachine-Infrastructure/lib/make_rpm.py --tag=${params.GIT_TAG_NAME}" --download
+                        sh "/usr/bin/python3 SapMachine-infrastructure/lib/make_rpm.py --tag=${params.GIT_TAG_NAME}" --download
                     }
                     post {
                         success {
@@ -207,14 +207,14 @@
                     }
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                            dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                             reuseNode true
                             label "linux_x86_64"
                         }
                     }
                     steps {
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                            sh "SapMachine-Infrastructure/lib/publish_rpm.sh"
+                            sh "SapMachine-infrastructure/lib/publish_rpm.sh"
                         }
                     }
                 }

--- a/jenkins-job-generator/definitions/ossrh-jobs.yml
+++ b/jenkins-job-generator/definitions/ossrh-jobs.yml
@@ -15,13 +15,13 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Upload') {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/ossrh-upload"
+                            dir "SapMachine-infrastructure/dockerfiles/ossrh-upload"
                             reuseNode true
                             label "repository"
                         }
@@ -29,7 +29,7 @@
                     steps {
                         withCredentials([file(credentialsId: 'SapMachine-secret-gpg-key', variable: 'GPGSEC'),
                                          file(credentialsId: 'OSSRH_SETTINGS', variable: 'OSSRH_SETTINGS_XML')]) {
-                            sh 'SapMachine-Infrastructure/lib/ossrh/upload.sh'
+                            sh 'SapMachine-infrastructure/lib/ossrh/upload.sh'
                         }
                     }
                 }

--- a/jenkins-job-generator/definitions/osx-jobs.yml
+++ b/jenkins-job-generator/definitions/osx-jobs.yml
@@ -94,13 +94,13 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Download artifacts') {
                     steps {
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                            sh "python3 SapMachine-Infrastructure/lib/download-osx-artifacts.py"
+                            sh "python3 SapMachine-infrastructure/lib/download-osx-artifacts.py"
                         }
                     }
                 }
@@ -133,7 +133,7 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Copy Upstream Artifacts') {
@@ -144,7 +144,7 @@
                 stage('Deploy') {
                     steps {
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                            sh "SapMachine-Infrastructure/lib/publish_osx.sh"
+                            sh "SapMachine-infrastructure/lib/publish_osx.sh"
                         }
                     }
                 }
@@ -183,14 +183,14 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[credentialsId: 'SapMachine-github', url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Create Brew Casks') {
                     steps {
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
                             lock('MacBrewCaskGenerationSynchronizer') {
-                                sh "python3 SapMachine-Infrastructure/lib/make_cask.py -t ${params.SAPMACHINE_VERSION}"
+                                sh "python3 SapMachine-infrastructure/lib/make_cask.py -t ${params.SAPMACHINE_VERSION}"
                             }
                         }
                     }

--- a/jenkins-job-generator/definitions/repository-jobs.yml
+++ b/jenkins-job-generator/definitions/repository-jobs.yml
@@ -27,10 +27,10 @@
                     steps {
                         sh '''#!/bin/bash
                             set -ex
-                            if [ ! -d SapMachine-Infrastructure ]; then
-                              git init SapMachine-Infrastructure
+                            if [ ! -d SapMachine-infrastructure ]; then
+                              git init SapMachine-infrastructure
                             fi
-                            cd SapMachine-Infrastructure
+                            cd SapMachine-infrastructure
                             git fetch --depth 1 https://github.com/SAP/SapMachine-infrastructure.git master
                             git checkout --detach FETCH_HEAD
                         '''
@@ -43,11 +43,11 @@
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
                             sh '''
-                                openjdk_repositories=$(python3 SapMachine-Infrastructure/lib/list_openjdk_repositories.py)
+                                openjdk_repositories=$(python3 SapMachine-infrastructure/lib/list_openjdk_repositories.py)
                                 for i in ${openjdk_repositories}
                                 do
                                     :
-                                    SapMachine-Infrastructure/lib/update_repo.sh $i
+                                    SapMachine-infrastructure/lib/update_repo.sh $i
                                 done
                             '''
                         }
@@ -74,7 +74,7 @@
                 stage('Tag, Build and Merge') {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                            dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                             reuseNode true
                             label "repository"
                         }
@@ -85,7 +85,7 @@
                     }
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
-                            sh("cd SapMachine && python3 ../SapMachine-Infrastructure/lib/tag_build_and_merge.py")
+                            sh("cd SapMachine && python3 ../SapMachine-infrastructure/lib/tag_build_and_merge.py")
                         }
                     }
                 }
@@ -110,7 +110,7 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage("Checkout Repository") {
@@ -121,7 +121,7 @@
                 stage('Merge') {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                            dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                             reuseNode true
                             label "repository"
                         }
@@ -130,7 +130,7 @@
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
                             script {
                                 env.ASYNC_PROF_BUILD_REQUIRED = sh(
-                                        script: "SapMachine-Infrastructure/lib/merge_async_prof.sh",
+                                        script: "SapMachine-infrastructure/lib/merge_async_prof.sh",
                                         returnStatus: true
                                 )
                             }
@@ -140,7 +140,7 @@
                 stage('Check Release') {
                     agent {
                         dockerfile {
-                            dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                            dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                             reuseNode true
                             label "repository"
                         }
@@ -149,7 +149,7 @@
                         withCredentials([usernamePassword(credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD')]) {
                             script {
                                 env.ASYNC_PROF_RELEASE_TAG = sh(
-                                        script: "python3 SapMachine-Infrastructure/lib/async_check_release.py",
+                                        script: "python3 SapMachine-infrastructure/lib/async_check_release.py",
                                         returnStdout: true
                                 )
                             }

--- a/jenkins-job-generator/definitions/website-jobs.yml
+++ b/jenkins-job-generator/definitions/website-jobs.yml
@@ -15,20 +15,20 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Generate Data') {
                     agent {
                           dockerfile {
-                              dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                              dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                               reuseNode true
                               label "website"
                           }
                       }
                       steps {
                           withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                              sh "python3 SapMachine-Infrastructure/lib/generate_website_data.py"
+                              sh "python3 SapMachine-infrastructure/lib/generate_website_data.py"
                           }
                       }
                   }
@@ -56,20 +56,20 @@
             stages {
                 stage("Checkout Infrastructure Repository") {
                     steps {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-Infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'SapMachine-infrastructure']], userRemoteConfigs: [[url: 'https://github.com/SAP/SapMachine-infrastructure.git']]]
                     }
                 }
                 stage('Generate Data') {
                     agent {
                           dockerfile {
-                              dir "SapMachine-Infrastructure/dockerfiles/infrastructure"
+                              dir "SapMachine-infrastructure/dockerfiles/infrastructure"
                               reuseNode true
                               label "website"
                           }
                       }
                       steps {
                           withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'SapMachine-github', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASSWORD']]) {
-                              sh "python3 SapMachine-Infrastructure/lib/generate_website_data_jmc.py"
+                              sh "python3 SapMachine-infrastructure/lib/generate_website_data_jmc.py"
                           }
                       }
                   }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -57,7 +57,7 @@ if [[ ! -z $JDK_BUILD ]]; then
 fi
 
 # need to do the python call first and the eval in a second step to bail out on $? != 0
-_CONFIGURE_OPTS=$(python3 ../SapMachine-Infrastructure/lib/get_configure_opts.py $_GIT_TAG $_JDK_BUILD)
+_CONFIGURE_OPTS=$(python3 ../SapMachine-infrastructure/lib/get_configure_opts.py $_GIT_TAG $_JDK_BUILD)
 eval _CONFIGURE_OPTS=(${_CONFIGURE_OPTS})
 
 (set -x &&

--- a/lib/jenkins_restore.py
+++ b/lib/jenkins_restore.py
@@ -16,7 +16,7 @@ jenkins_configuration = 'jenkins_configuration'
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('-t', '--targetdir', help='the target directory (Jenkins home directory)', metavar='DIR', required=True)
-    parser.add_argument('-b', '--backuprepodir', help='the backup repository', metavar='DIR', default='SapMachine-Infrastructure')
+    parser.add_argument('-b', '--backuprepodir', help='the backup repository', metavar='DIR', default='SapMachine-infrastructure')
     parser.add_argument('--install-plugins', help='install the Jenkins plugins', action='store_true', default=False)
     parser.add_argument('--plugins-only', help='install only the Jenkins plugins (implies --install-plugins)', action='store_true', default=False)
     args = parser.parse_args()

--- a/lib/make_deb.py
+++ b/lib/make_deb.py
@@ -135,7 +135,7 @@ def main(argv=None):
     jdk_exploded_image = glob.glob(join(jdk_dir, 'sapmachine-*'))[0]
 
     generate_configuration(
-        templates_dir = join(realpath("SapMachine-Infrastructure/debian-templates"), 'jdk'),
+        templates_dir = join(realpath("SapMachine-infrastructure/debian-templates"), 'jdk'),
         major = str(major),
         arch = "arm64" if args.architecture == "linux-aarch64" else ("ppc64el" if args.architecture == "linux-ppc64le" else "amd64"),
         target_dir = join(jdk_dir, 'debian'),

--- a/lib/ossrh/upload.sh
+++ b/lib/ossrh/upload.sh
@@ -12,7 +12,7 @@ cd upload
 
 mvn --version
 
-cp ../SapMachine-Infrastructure/lib/ossrh/upload_pom.xml .
+cp ../SapMachine-infrastructure/lib/ossrh/upload_pom.xml .
 sed -i "s/\${type}/jre/g" upload_pom.xml
 sed -i "s/\${version}/$VERSION/g" upload_pom.xml
 sed -i "s/\${maven.name}/SapMachine JRE/g" upload_pom.xml
@@ -25,7 +25,7 @@ else
 fi
 mvn -B --no-transfer-progress --settings $OSSRH_SETTINGS_XML -f upload_pom.xml clean deploy
 
-cp -f ../SapMachine-Infrastructure/lib/ossrh/upload_pom.xml .
+cp -f ../SapMachine-infrastructure/lib/ossrh/upload_pom.xml .
 sed -i "s/\${type}/jdk/g" upload_pom.xml
 sed -i "s/\${version}/$VERSION/g" upload_pom.xml
 sed -i "s/\${maven.name}/SapMachine JDK/g" upload_pom.xml

--- a/lib/publish.sh
+++ b/lib/publish.sh
@@ -20,7 +20,7 @@ if [[ -z "$SAPMACHINE_VERSION" ]]; then
   echo "SAPMACHINE_VERSION not set"
   exit 1
 fi
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION $PRE_RELEASE_OPT || true
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION $PRE_RELEASE_OPT || true
 
 ls -la
 
@@ -43,17 +43,17 @@ shasum -a 256 $ARCHIVE_NAME_JDK > $ARCHIVE_SUM_JDK
 shasum -a 256 $ARCHIVE_NAME_JRE > $ARCHIVE_SUM_JRE
 shasum -a 256 $ARCHIVE_NAME_SYMBOLS > $ARCHIVE_SUM_SYMBOLS
 
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_NAME_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_NAME_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_NAME_SYMBOLS}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_SUM_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_SUM_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_SUM_SYMBOLS}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_NAME_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_NAME_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_NAME_SYMBOLS}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_SUM_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_SUM_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${ARCHIVE_SUM_SYMBOLS}"
 
 if [[ $UNAME == "Linux" ]] && [ "$RELEASE" == true ]; then
   for RPMFILE in *.rpm; do
     [ -f "$RPMFILE" ] || continue
-    python3 SapMachine-Infrastructure/lib/github_publish.py -t ${SAPMACHINE_VERSION} -a ${RPMFILE}
+    python3 SapMachine-infrastructure/lib/github_publish.py -t ${SAPMACHINE_VERSION} -a ${RPMFILE}
   done
 fi
 
@@ -67,16 +67,16 @@ if [ $UNAME == Darwin ]; then
   shasum -a 256 $DMG_NAME_JDK > $DMG_SUM_JDK
   shasum -a 256 $DMG_NAME_JRE > $DMG_SUM_JRE
 
-  python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_NAME_JDK}"
-  python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_NAME_JRE}"
-  python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_SUM_JDK}"
-  python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_SUM_JRE}"
+  python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_NAME_JDK}"
+  python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_NAME_JRE}"
+  python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_SUM_JDK}"
+  python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${DMG_SUM_JRE}"
 fi
 
 if [[ $UNAME == CYGWIN* ]]; then
   for MSIFILE in *.msi; do
     shasum -a 256 $MSIFILE > ${MSIFILE}.sha256.txt
-    python3 SapMachine-Infrastructure/lib/github_publish.py -t ${SAPMACHINE_VERSION} -a ${MSIFILE}
-    python3 SapMachine-Infrastructure/lib/github_publish.py -t ${SAPMACHINE_VERSION} -a ${MSIFILE}.sha256.txt
+    python3 SapMachine-infrastructure/lib/github_publish.py -t ${SAPMACHINE_VERSION} -a ${MSIFILE}
+    python3 SapMachine-infrastructure/lib/github_publish.py -t ${SAPMACHINE_VERSION} -a ${MSIFILE}.sha256.txt
   done
 fi

--- a/lib/publish_async_prof.sh
+++ b/lib/publish_async_prof.sh
@@ -3,4 +3,4 @@ set -ex
 
 ARCHIVE_NAME="$(cat async-profiler/artifact.txt)"
 
-python3 SapMachine-Infrastructure/lib/github_publish_asyncprof.py  -t $GIT_TAG_NAME -a "${ARCHIVE_NAME}"
+python3 SapMachine-infrastructure/lib/github_publish_asyncprof.py  -t $GIT_TAG_NAME -a "${ARCHIVE_NAME}"

--- a/lib/publish_osx.sh
+++ b/lib/publish_osx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-read VERSION OS_NAME<<< $(python3 ${WORKSPACE}/SapMachine-Infrastructure/lib/publish_osx_get_version_osname.py -t ${SAPMACHINE_VERSION})
+read VERSION OS_NAME<<< $(python3 ${WORKSPACE}/SapMachine-infrastructure/lib/publish_osx_get_version_osname.py -t ${SAPMACHINE_VERSION})
 
 INTEL_ARCHIVE_NAME_JDK="sapmachine-jdk-${VERSION}_${OS_NAME}-x64_bin.tar.gz"
 INTEL_ARCHIVE_NAME_JRE="sapmachine-jre-${VERSION}_${OS_NAME}-x64_bin.tar.gz"
@@ -47,27 +47,27 @@ shasum -a 256 $AARCH_ARCHIVE_NAME_SYMBOLS > $AARCH_ARCHIVE_SUM_SYMBOLS
 shasum -a 256 $AARCH_DMG_NAME_JDK > $AARCH_DMG_SUM_JDK
 shasum -a 256 $AARCH_DMG_NAME_JRE > $AARCH_DMG_SUM_JRE
 
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_NAME_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_NAME_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_NAME_SYMBOLS}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_SUM_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_SUM_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_SUM_SYMBOLS}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_NAME_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_NAME_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_SUM_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_SUM_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_NAME_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_NAME_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_NAME_SYMBOLS}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_SUM_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_SUM_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_SUM_SYMBOLS}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_NAME_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_NAME_JRE}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_SUM_JDK}"
-python3 SapMachine-Infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_SUM_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_NAME_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_NAME_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_NAME_SYMBOLS}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_SUM_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_SUM_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_ARCHIVE_SUM_SYMBOLS}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_NAME_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_NAME_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_SUM_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${INTEL_DMG_SUM_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_NAME_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_NAME_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_NAME_SYMBOLS}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_SUM_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_SUM_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_ARCHIVE_SUM_SYMBOLS}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_NAME_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_NAME_JRE}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_SUM_JDK}"
+python3 SapMachine-infrastructure/lib/github_publish.py -t $SAPMACHINE_VERSION -a "${AARCH_DMG_SUM_JRE}"
 
 if [ "$PUBLISH_CASKS" == true ]; then
-    python3 SapMachine-Infrastructure/lib/make_cask.py -t $SAPMACHINE_VERSION
+    python3 SapMachine-infrastructure/lib/make_cask.py -t $SAPMACHINE_VERSION
 fi

--- a/lib/publish_rpm.sh
+++ b/lib/publish_rpm.sh
@@ -2,4 +2,4 @@
 set -ex
 
 RPMFILE=$(ls *.rpm)
-python3 SapMachine-Infrastructure/lib/github_publish.py -t ${GIT_TAG_NAME} -a ${RPMFILE}
+python3 SapMachine-infrastructure/lib/github_publish.py -t ${GIT_TAG_NAME} -a ${RPMFILE}


### PR DESCRIPTION
'SapMachine-infrastructure'

The main repository for SapMachine-infrastructure is https://github.com/SAP/SapMachine-infrastructure/ . Based on git's default behaviour for 'git clone' this repository will be cloned into a local repository 'SapMachine-infrastructure'. But in the jenkins environment on ci.sapmachine.io the scripts and jobs will explicitly clone this repo in a folder 'SapMachine-Infrastructure' where only the second 'i' is capitalized. Developer of scripts and jobs have to keep in mind that the local folder name is different from the last part of the git repo name.
This commit renames the folder name SapMachine-Infrastructure to SapMachine-infrastructure everywhere where the old name is mentioned in the main branch of mentioned repository.

This commit was produced by the following command:

git grep -l SapMachine-Infrastructure | xargs sed -i '' -e 's/SapMachine-Infrastructure/SapMachine-infrastructure/g'

When this commit is checked out the following command visualizes nicely the exact character-level changes the commit introduced:

git show --word-diff-regex=.