### PR TITLE
GardenLinux Images - Update 24 to 25

### DIFF
--- a/.github/workflows/publish-gardenlinux-imageOnce-DoNotUse.yml
+++ b/.github/workflows/publish-gardenlinux-imageOnce-DoNotUse.yml
@@ -8,7 +8,7 @@ jobs:
   publish_images:
     strategy:
         matrix:
-          sapMachineVersion: [24]
+          sapMachineVersion: [25]
           gardenLinuxVersion: [1592]
     uses: ./.github/workflows/publish-container-images.yml
     with:


### PR DESCRIPTION
SapMachine 25 was released. this will build the 25 images the first time
after merge this must be executed once