### PR TITLE
Merge After Support of SapMachine 24 ended - Update SapMachine 24 to 25

### DIFF
--- a/.github/workflows/publish-gardenlinux-images.yml
+++ b/.github/workflows/publish-gardenlinux-images.yml
@@ -8,7 +8,7 @@ jobs:
   publish_images:
     strategy:
         matrix:
-          sapMachineVersion: [17, 21, 24]
+          sapMachineVersion: [17, 21, 25]
           gardenLinuxVersion: [1592]
     uses: ./.github/workflows/publish-container-images.yml
     with:


### PR DESCRIPTION
After the support time frame of SapMachine 24 ended, please merge this PR.
No need to execute this afterwards