### PR TITLE
force Orca to scan

### DIFF
--- a/.github/workflows/publish-gardenlinux-on-change.yml
+++ b/.github/workflows/publish-gardenlinux-on-change.yml
@@ -326,7 +326,7 @@ jobs:
           podman manifest push ghcr.io/sap/sapmachine:latest docker://ghcr.io/sap/sapmachine:latest
 
   # ============================================================================
-  # Job 4: Send failure notification email if any previous job failed
+  # Job 4: Send failure notification email if any previous jobs failed
   # ============================================================================
   notify-on-failure:
     name: Send failure notification email


### PR DESCRIPTION
internal # TGSAPJVM-6104

Based on our interaction with the Orca support, they perform scans for repository configuration when new code is pushed to the repository (but only up to one time a day).