### PR TITLE
ci: pass GITHUB_TOKEN to stats script step

### DIFF
--- a/.github/workflows/nightly-snapshot.yml
+++ b/.github/workflows/nightly-snapshot.yml
@@ -42,6 +42,8 @@ jobs:
 
     # 6. Run the Python script to fetch and append download stats
     - name: Run Python script to fetch and append download stats
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: python .github/scripts/fetch_and_append_stats.py
 
     # 7. Configure Git for committing


### PR DESCRIPTION
## Summary

Adds `GITHUB_TOKEN` as an env variable to the Python step that runs `fetch_and_append_stats.py` from the `release_stats` branch.

## Why

The companion PR **#77** (against `release_stats`) switches that script to GitHub's GraphQL API, which is the only way to work around the `/repos/.../releases` REST endpoint's hard ~1000-result pagination cap. The cap was causing the oldest releases (e.g. `sapmachine-11.0.2` with 1.94 M downloads) to silently fall out of the snapshots.

GraphQL requires authentication. The workflow must therefore pass `GITHUB_TOKEN` to the script's environment.

## Diff

```yaml
    # 6. Run the Python script to fetch and append download stats
    - name: Run Python script to fetch and append download stats
+     env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      run: python .github/scripts/fetch_and_append_stats.py
```

That's the entire change.

## Merge order

This PR is **forward-compatible** with the current script (an unused env var is harmless), so it can be merged at any time — ideally **before** #77, so that when the script update lands the workflow already has the env var ready.

## Related

- #77 — switches `fetch_and_append_stats.py` to GraphQL (against `release_stats` branch)