### PR TITLE
fix(stats): paginate release assets and retry 403/429 rate limits

### DIFF
--- a/.github/scripts/fetch_and_append_stats.py
+++ b/.github/scripts/fetch_and_append_stats.py
@@ -32,14 +32,15 @@ REPO = "SapMachine"
 GRAPHQL_QUERY = """
 query($owner: String!, $repo: String!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
-    releases(first: 25, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
+    releases(first: 15, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
       pageInfo { hasNextPage endCursor }
       nodes {
+        id
         databaseId
         name
         tagName
         isPrerelease
-        releaseAssets(first: 25) {
+        releaseAssets(first: 30) {
           pageInfo { hasNextPage endCursor }
           nodes {
             name
@@ -54,10 +55,10 @@ query($owner: String!, $repo: String!, $cursor: String) {
 
 # Falls ein Release mehr als 100 Assets hat, paginieren wir die Assets nach.
 GRAPHQL_ASSETS_QUERY = """
-query($owner: String!, $repo: String!, $releaseId: ID!, $cursor: String) {
+query($releaseId: ID!, $cursor: String) {
   node(id: $releaseId) {
     ... on Release {
-      releaseAssets(first: 100, after: $cursor) {
+      releaseAssets(first: 50, after: $cursor) {
         pageInfo { hasNextPage endCursor }
         nodes { name downloadCount }
       }
@@ -67,8 +68,16 @@ query($owner: String!, $repo: String!, $releaseId: ID!, $cursor: String) {
 """
 
 
-def _post_graphql(query, variables, headers, max_attempts=4):
-    """POST with retry on transient errors (5xx, timeouts)."""
+# HTTP status codes considered transient (worth retrying with backoff).
+# - 5xx: server errors / timeouts
+# - 403: GitHub's secondary rate limit / abuse detection often surfaces
+#        as 403 with a "rate limit" message in the body
+# - 429: explicit rate limit
+_RETRYABLE_STATUS = {403, 429, 500, 502, 503, 504}
+
+
+def _post_graphql(query, variables, headers, max_attempts=6):
+    """POST with retry on transient errors (5xx, 403/429 rate limits, timeouts)."""
     last_exc = None
     for attempt in range(1, max_attempts + 1):
         try:
@@ -78,19 +87,26 @@ def _post_graphql(query, variables, headers, max_attempts=4):
                 headers=headers,
                 timeout=60,
             )
-            if resp.status_code in (502, 503, 504):
+            if resp.status_code in _RETRYABLE_STATUS:
+                # Honor Retry-After if present, else exponential backoff.
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after and retry_after.isdigit():
+                    wait = int(retry_after)
+                else:
+                    wait = 2 ** attempt
                 logging.warning(
-                    "GraphQL %d on attempt %d, retrying...", resp.status_code, attempt
+                    "GraphQL HTTP %d on attempt %d (body: %s), sleeping %ds...",
+                    resp.status_code, attempt, resp.text[:200], wait,
                 )
-                time.sleep(2 ** attempt)
+                time.sleep(wait)
                 continue
             resp.raise_for_status()
             body = resp.json()
             if "errors" in body:
-                # Some GraphQL errors are transient (rate limit). Retry once.
                 err_str = str(body["errors"])
-                if "rate limit" in err_str.lower() or "timeout" in err_str.lower():
-                    logging.warning("Transient GraphQL error: %s", err_str)
+                lowered = err_str.lower()
+                if any(t in lowered for t in ("rate limit", "timeout", "secondary")):
+                    logging.warning("Transient GraphQL error: %s", err_str[:200])
                     time.sleep(2 ** attempt)
                     continue
                 raise RuntimeError(f"GraphQL errors: {body['errors']}")
@@ -105,6 +121,23 @@ def _post_graphql(query, variables, headers, max_attempts=4):
     raise RuntimeError(
         f"GraphQL request failed after {max_attempts} attempts: {last_exc}"
     )
+
+
+def _fetch_remaining_assets(release_node_id, after_cursor, headers):
+    """Fetch additional asset pages for a release that has >30 assets."""
+    extra_assets = []
+    cursor = after_cursor
+    while cursor is not None:
+        body = _post_graphql(
+            GRAPHQL_ASSETS_QUERY,
+            {"releaseId": release_node_id, "cursor": cursor},
+            headers,
+        )
+        page = body["data"]["node"]["releaseAssets"]
+        extra_assets.extend(page["nodes"])
+        cursor = page["pageInfo"]["endCursor"] if page["pageInfo"]["hasNextPage"] else None
+        time.sleep(0.3)
+    return extra_assets
 
 
 def fetch_release_stats():
@@ -123,15 +156,21 @@ def fetch_release_stats():
         page = body["data"]["repository"]["releases"]
         for node in page["nodes"]:
             assets = list(node["releaseAssets"]["nodes"])
-            # Asset-Pagination falls >100 Assets pro Release (sehr selten)
-            if node["releaseAssets"]["pageInfo"]["hasNextPage"]:
-                logging.warning(
-                    "Release %s has >100 assets, paginating...", node["tagName"]
+            # If the release has more assets than fit on one page,
+            # fetch the rest through the dedicated assets-only query.
+            asset_page_info = node["releaseAssets"]["pageInfo"]
+            if asset_page_info["hasNextPage"]:
+                logging.info(
+                    "Release %s has >30 assets, fetching remaining pages...",
+                    node["tagName"],
                 )
-                # databaseId reicht hier nicht, wir brauchen die GraphQL node id.
-                # Fuer Einfachheit: ueberspringen und Warnung loggen.
-                # (In der Praxis hat SapMachine ~22 Assets pro Release,
-                #  also ist das nie ein Problem.)
+                extra = _fetch_remaining_assets(
+                    node["id"], asset_page_info["endCursor"], headers,
+                )
+                assets.extend(extra)
+                logging.info(
+                    "  -> total %d assets for %s", len(assets), node["tagName"],
+                )
 
             releases.append({
                 "id": node["databaseId"],
@@ -147,7 +186,7 @@ def fetch_release_stats():
         if not page["pageInfo"]["hasNextPage"]:
             break
         cursor = page["pageInfo"]["endCursor"]
-        time.sleep(0.3)  # nett zur API
+        time.sleep(0.5)  # nett zur API
 
     logging.info("Fetched %d releases via GraphQL.", len(releases))
 


### PR DESCRIPTION
## Background

After #77 + #78 landed, the first nightly run on 2026-06-17 failed with:

```
WARNING:root:Release sapmachine-21.0.8+9 has >100 assets, paginating...
WARNING:root:Release sapmachine-24.0.2 has >100 assets, paginating...
... (more 'paginating' warnings) ...
ERROR:root:Script failed: 403 Client Error: Forbidden for url: https://api.github.com/graphql
```

Two distinct issues:

### Issue 1 — Asset truncation (silent data loss)

The `releaseAssets(first: 25)` clause in the outer query was already too small for some pre-release builds (e.g. `sapmachine-24.0.2`, `sapmachine-25+30`, `sapmachine-21.0.8+9`), which carry 30-56 assets each. The previous code logged a 'paginating...' warning but actually **didn't paginate** — it just dropped the surplus assets. Result: silently incomplete download stats.

### Issue 2 — 403 not retried

The page combo (25 releases × 25 assets = 625 GraphQL nodes) occasionally triggered GitHub's secondary rate limit / abuse detection, which arrives as plain **HTTP 403 with no `Retry-After` header** — and the previous `_post_graphql` only retried on 5xx, so the whole run aborted on the first 403.

## Fix

- Outer page **25 → 15**, asset page **25 → 30** (lower per-request complexity)
- **Properly paginate assets** when a release has more than 30: use a follow-up `GRAPHQL_ASSETS_QUERY` keyed by the release's GraphQL node `id` (now fetched alongside `databaseId`)
- `_post_graphql` retries **403, 429, 500, 502, 503, 504** with exponential backoff, honoring `Retry-After` when present
- Bumped inter-page sleep 0.3s → 0.5s to be gentler on the rate limiter

## Verification

Ran locally with a PAT. Log excerpt:

```
INFO:root:Release sapmachine-27+26 has >30 assets, fetching remaining pages...
INFO:root:  -> total 46 assets for sapmachine-27+26
INFO:root:Release sapmachine-21.0.12+6 has >30 assets, fetching remaining pages...
INFO:root:  -> total 56 assets for sapmachine-21.0.12+6
```

i.e. assets that were previously truncated to 25 now show their full count (46, 56, …) in the CSV. Output schema unchanged.

## Output schema impact

**None.** Same columns, same value types, same semantics.

## Related

- #77 — switch to GraphQL (merged)
- #78 — pass `GITHUB_TOKEN` to workflow step (merged)